### PR TITLE
noasync: drop nodelay option

### DIFF
--- a/greeter-noasync/src/main.rs
+++ b/greeter-noasync/src/main.rs
@@ -87,7 +87,6 @@ impl Drop for Client {
 
 impl Client {
     fn new(mut stream: TcpStream) -> Self {
-        stream.set_nodelay(true).unwrap();
         let raw_fd = stream.as_raw_fd();
         let token = Token(raw_fd as usize);
 


### PR DESCRIPTION
enabling nodelay option makes the performance worse.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>